### PR TITLE
feat: Notes RSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <!-- <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#ffffff"> -->
+  <link rel="alternate" type="application/rss+xml" title="Anthony Fu (Blog)" href="/feed.xml">
+  <link rel="alternate" type="application/rss+xml" title="Anthony Fu (Notes)" href="/feed-notes.xml">
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="theme-color" content="#ffffff">
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code&family=Inter:wght@200;400;600&display=swap" rel="stylesheet">

--- a/pages/notes.md
+++ b/pages/notes.md
@@ -10,7 +10,7 @@ description: Quick notes / tips
 
 ## Typed `provide` and `inject` in Vue
 
-_2020/03/05_
+_2021/03/05_
 
 I didn't know that you can type `provide()` and `inject()` elegantly until I watched [Thorsten Lünborg](https://github.com/LinusBorg/)'s talk on [Vue Amsterdam](https://vuejs.amsterdam/).
 
@@ -68,7 +68,7 @@ See [the docs](https://v3.vuejs.org/api/composition-api.html#provide-inject) for
 
 ## Color Scheme for VS Code Extensions
 
-_2020/03/01_
+_2021/03/01_
 
 There is currently no API to access colors of current theme in VS Code Extensions, nor the meta infomation of them. It frustrated me for a long while, until today I came up with a dirty but working solution.
 
@@ -101,7 +101,7 @@ Simple, but surprisingly, it works really well. This is used for my [Browse Lite
 
 ## Type Your Config
 
-_2020/02/29_
+_2021/02/29_
 
 Configurations can be quite complex, and sometimes you may want to utilize the great type checking that TypeScript provided. Change your `xxx.config.js` to `xxx.config.ts` is not an ideal solutions as you will need to have a Node.js register involved to transplie it into JavaScript and some tools might not support doing that way. Fortunately, TypeScript also support type check in plain JavaScript file with JSDoc. Here is an example of Webpack config with type checks:
 
@@ -151,7 +151,7 @@ export function defineConfig(options: UserConfig) {
 
 ## Match Quotes in Pairs
 
-_2020/02/28_
+_2021/02/28_
 
 In JavaScript, single quotes('') and double quotes("") are interchangable. With ES6, we now even have backticks(``) for template literals. When you want to write a quick script to find all the strings without introducing a heavy parser, you may think about using RegExp. For example, you can have:
 
@@ -190,7 +190,7 @@ You can find it running in action on my [`vite-plugin-windicss`](https://github.
 
 ## Match Chinese Characters
 
-_2020/02/25_
+_2021/02/25_
 
 When you need to detect if a string contains Chinese characters, you would commonly think about doing it will RegExp, or grab a ready-to-use package on npm.
 
@@ -219,7 +219,7 @@ It's called [Unicode property escapes](https://developer.mozilla.org/en-US/docs/
 
 ## Netlify Redirects (Domains)
 
-_2020/02/20_
+_2021/02/20_
 
 On [Netlify](https://netlify.com), you can setup multiple domains for a site. When you add a custom domain, the `xxx.netlify.app` is still accessable. Which would potentially cause some confusion to users. In that way, you can setup the redirection in your `netlify.toml` file, for example:
 
@@ -239,7 +239,7 @@ On [Netlify](https://netlify.com), you can setup multiple domains for a site. Wh
 
 ## Netlify Redirects (Site names)
 
-_2020/02/20_
+_2021/02/20_
 
 Unlike domain redirection, sometimes you would need to rename the Netlify subdomain name (a.k.a site name), for example `xxx.netlify.app` to `yyy.netlify.app`. After you do the rename, people visiting `xxx.netlify.app` will receive a 404. And since you no longer have controls over `xxx.netlify.app`, you can't just setup a redirect in your new site.
 

--- a/pages/notes.md
+++ b/pages/notes.md
@@ -70,7 +70,7 @@ See [the docs](https://v3.vuejs.org/api/composition-api.html#provide-inject) for
 
 _2021/03/01_
 
-There is currently no API to access colors of current theme in VS Code Extensions, nor the meta infomation of them. It frustrated me for a long while, until today I came up with a dirty but working solution.
+There is currently no API to access colors of current theme in VS Code Extensions, nor the meta information of them. It frustrated me for a long while, until today I came up with a dirty but working solution.
 
 Since most of the themes follow the conversions of having `Light` or `Dark` in their names. Then we can have:
 
@@ -103,7 +103,7 @@ Simple, but surprisingly, it works really well. This is used for my [Browse Lite
 
 _2021/02/29_
 
-Configurations can be quite complex, and sometimes you may want to utilize the great type checking that TypeScript provided. Change your `xxx.config.js` to `xxx.config.ts` is not an ideal solutions as you will need to have a Node.js register involved to transplie it into JavaScript and some tools might not support doing that way. Fortunately, TypeScript also support type check in plain JavaScript file with JSDoc. Here is an example of Webpack config with type checks:
+Configurations can be quite complex, and sometimes you may want to utilize the great type checking that TypeScript provided. Change your `xxx.config.js` to `xxx.config.ts` is not an ideal solutions as you will need to have a Node.js register involved to transpile it into JavaScript and some tools might not support doing that way. Fortunately, TypeScript also support type check in plain JavaScript file with JSDoc. Here is an example of Webpack config with type checks:
 
 ```ts
 // webpack.config.js
@@ -144,7 +144,7 @@ export function defineConfig(options: UserConfig) {
 }
 ```
 
-`defineConfig` exists in the runtime, so it works for JavaScript even if the types get truncated. This is really just some small details of DX, but I would wish more tools could adapt this approach and make the type checking more approachable and simplier.
+`defineConfig` exists in the runtime, so it works for JavaScript even if the types get truncated. This is really just some small details of DX, but I would wish more tools could adapt this approach and make the type checking more approachable and simpler.
 
 </article>
 <article>
@@ -153,7 +153,7 @@ export function defineConfig(options: UserConfig) {
 
 _2021/02/28_
 
-In JavaScript, single quotes('') and double quotes("") are interchangable. With ES6, we now even have backticks(``) for template literals. When you want to write a quick script to find all the strings without introducing a heavy parser, you may think about using RegExp. For example, you can have:
+In JavaScript, single quotes('') and double quotes("") are interchangeable. With ES6, we now even have backticks(``) for template literals. When you want to write a quick script to find all the strings without introducing a heavy parser, you may think about using RegExp. For example, you can have:
 
 ```ts
 /['"`](.*?)['"`]/gm
@@ -210,9 +210,9 @@ It works, but a bit dirty. Fortunately, I found [a much simpler solution](https:
 !!'你好'.match(/\p{Script=Han}/u) // true
 ```
 
-It's called [Unicode property escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) and already avaliable in [Chrome 64, Firefox 79, Safari 11.1 and Node.js 10](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility).
+It's called [Unicode property escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) and already available in [Chrome 64, Firefox 79, Safari 11.1 and Node.js 10](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility).
 
-[All avaliable scripts here](https://www.regular-expressions.info/unicode.html).
+[All available scripts here](https://www.regular-expressions.info/unicode.html).
 
 </article>
 <article>
@@ -221,7 +221,7 @@ It's called [Unicode property escapes](https://developer.mozilla.org/en-US/docs/
 
 _2021/02/20_
 
-On [Netlify](https://netlify.com), you can setup multiple domains for a site. When you add a custom domain, the `xxx.netlify.app` is still accessable. Which would potentially cause some confusion to users. In that way, you can setup the redirection in your `netlify.toml` file, for example:
+On [Netlify](https://netlify.com), you can setup multiple domains for a site. When you add a custom domain, the `xxx.netlify.app` is still accessible. Which would potentially cause some confusion to users. In that way, you can setup the redirection in your `netlify.toml` file, for example:
 
 ```toml
 [[redirects]]
@@ -232,7 +232,7 @@ On [Netlify](https://netlify.com), you can setup multiple domains for a site. Wh
 ```
 
 - `*` and `:splat` mean it will redirect all the sub routes as-is to the new domain.
-- `force = true` specifing it will always redirect even if the request page exists.
+- `force = true` specifying it will always redirect even if the request page exists.
 
 </article>
 <article>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -25,7 +25,7 @@ import { isDark } from '/~/logics'
         <router-link to="/bookmarks" title="Bookmarks">
           <ri-bookmark-line />
         </router-link>
-        <router-link to="/notes" title="Bookmarks">
+        <router-link to="/notes" title="Notes">
           <ri-sticky-note-line />
         </router-link>
         <a href="https://twitter.com/antfu7" target="_blank" title="Twitter" class="hidden md:block">


### PR DESCRIPTION
Hi there!

I've enjoyed reading your notes and I thought it'd be nice to have a RSS feed for them as well :). At the moment, the script relies on the notes being separated by `<article>` tags, if you ever stop doing that it should be easy to modify the script to split notes looking for h2 tags (or `/##[^#].*\n/` in markdown). It's also getting everything from a single file, so if you ever start doing pagination it'll break as well. Hopefully this can serve you for a long time until then :).

I also found some typos, if you write your notes and posts in VSCode I suggest that your install this extension, as a non-native english speaker myself I find it really useful: [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker).

I've also added a couple of links to the `<head>`, this allows browsers to show links to the feeds in the navigation bar (and I think that's how many readers find feeds if you type a site url, but I'm not 100% sure about that). You'll probably want to add the links to the notes RSS somewhere on the notes page as well, but I didn't do it because I'm not sure how you'd want it.