### PR TITLE
fix: navbar causing horizontal overflow

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -56,7 +56,7 @@ import { isDark } from '/~/logics'
 
 .nav {
   padding: 2rem;
-  width: 100vw;
+  width: 100%;
   display: grid;
   grid-template-columns: auto max-content;
   box-sizing: border-box;


### PR DESCRIPTION
Just got done reading your article about windicss(nice one btw 🙂) and noticed that there was a horizontal overflow on the page. This was caused by the navbar using `100vw` instead `100%` for it's width which ended up causing a horizontal overflow whenever the page had a vertical scrollbar.