### PR TITLE
chore: update extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "octref.vetur",
-    "antfu.i18n-ally",
+    "lokalise.i18n-ally",
     "antfu.iconify",
     "dbaeumer.vscode-eslint",
     "bradlc.vscode-tailwindcss"


### PR DESCRIPTION
It seems `antfu.i18n-ally` has renamed to `lokalise.i18n-ally`.