### PR TITLE
chore: fix regex demo

### DIFF
--- a/pages/posts/reimagine-atomic-css-zh.md
+++ b/pages/posts/reimagine-atomic-css-zh.md
@@ -292,8 +292,8 @@ rules: [
 
 ```ts
 rules: [
-  [/^m-(\d)$/, ([, d]) => ({ margin: `${d / 4}rem` })],
-  [/^p-(\d)$/, (match) => ({ padding: `${match[1] / 4}rem` })],
+  [/^m-(\d+)$/, ([, d]) => ({ margin: `${d / 4}rem` })],
+  [/^p-(\d+)$/, (match) => ({ padding: `${match[1] / 4}rem` })],
 ]
 ```
 

--- a/pages/posts/reimagine-atomic-css.md
+++ b/pages/posts/reimagine-atomic-css.md
@@ -288,8 +288,8 @@ To make it dynamic, change the matcher to a RegExp and the body to a function:
 
 ```ts
 rules: [
-  [/^m-(\d)$/, ([, d]) => ({ margin: `${d / 4}rem` })],
-  [/^p-(\d)$/, (match) => ({ padding: `${match[1] / 4}rem` })],
+  [/^m-(\d+)$/, ([, d]) => ({ margin: `${d / 4}rem` })],
+  [/^p-(\d+)$/, (match) => ({ padding: `${match[1] / 4}rem` })],
 ]
 ```
 


### PR DESCRIPTION
In order to match classes like `m-100`, the regex needs an extra `+`.