### PR TITLE
feat: add cypress env in npm-binary-mirrors post

### DIFF
--- a/pages/posts/npm-binary-mirrors.md
+++ b/pages/posts/npm-binary-mirrors.md
@@ -28,4 +28,6 @@ export SAUCECTL_INSTALL_BINARY_MIRROR="https://cdn.npmmirror.com/binaries/saucec
 export npm_config_sharp_binary_host="https://cdn.npmmirror.com/binaries/sharp"
 export npm_config_sharp_libvips_binary_host="https://cdn.npmmirror.com/binaries/sharp-libvips"
 export npm_config_robotjs_binary_host="https://cdn.npmmirror.com/binaries/robotj"
+# 注意：下面仅适用于cypress >= 10.6.0, https://docs.cypress.io/guides/references/changelog#10-6-0
+export CYPRESS_DOWNLOAD_PATH_TEMPLATE='https://cdn.npmmirror.com/binaries/cypress/${version}/${platform}-${arch}/cypress.zip'
 ```

--- a/pages/posts/npm-binary-mirrors.md
+++ b/pages/posts/npm-binary-mirrors.md
@@ -28,6 +28,6 @@ export SAUCECTL_INSTALL_BINARY_MIRROR="https://cdn.npmmirror.com/binaries/saucec
 export npm_config_sharp_binary_host="https://cdn.npmmirror.com/binaries/sharp"
 export npm_config_sharp_libvips_binary_host="https://cdn.npmmirror.com/binaries/sharp-libvips"
 export npm_config_robotjs_binary_host="https://cdn.npmmirror.com/binaries/robotj"
-# 注意：下面仅适用于cypress >= 10.6.0, https://docs.cypress.io/guides/references/changelog#10-6-0
+# For Cypress >=10.6.0, https://docs.cypress.io/guides/references/changelog#10-6-0
 export CYPRESS_DOWNLOAD_PATH_TEMPLATE='https://cdn.npmmirror.com/binaries/cypress/${version}/${platform}-${arch}/cypress.zip'
 ```


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Since v10.6.0, Cypress enhanced the [CYPRESS_DOWNLOAD_PATH_TEMPLATE](https://docs.cypress.io/guides/references/advanced-installation#Environment-variables) environment variable interpolation to accept and replace `${version}` to allow version-specific download paths to be honored. Therefore, for developers in China, we can also set environment variables to download Cypress binary from [npmmirror](https://npmmirror.com/):

```bash
CYPRESS_DOWNLOAD_PATH_TEMPLATE='https://cdn.npmmirror.com/binaries/cypress/${version}/${platform}-${arch}/cypress.zip'
```

Changelog: https://docs.cypress.io/guides/references/changelog#10-6-0

### Linked Issues

https://github.com/cypress-io/cypress/issues/22864

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Note this env will raise error if user try to install Cypress < 10.6.0
