### PR TITLE
chore: update redirects

### DIFF
--- a/_dist_redirects
+++ b/_dist_redirects
@@ -19,6 +19,8 @@
 /talks/2021-10-17 https://github.com/antfu/talks/blob/master/2021-10-17/2021-10-17-laravel-vue-taiwan.pdf?raw=true 302
 /talks/2021-10-20 https://github.com/antfu/talks/blob/master/2021-10-20/2021-10-20-vue-london.pdf?raw=true 302
 /talks/2022-01-26 https://github.com/antfu/talks/blob/master/2022-01-26/2022-01-26-vue-nation.pdf?raw=true 302
+/talks/2022-10-11 https://github.com/antfu/talks/blob/master/2022-10-11/2022-10-11-vite-on-demand-dx.pdf?raw=true 302
+/talks/2022-10-16 https://github.com/antfu/talks/blob/master/2022-10-16/2022-10-16-vue-fes-japan-en.pdf?raw=true 302
 
 /vueuse https://github.com/vueuse/vueuse 302
 /vue-demi https://github.com/vueuse/vue-demi 302


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Your new talks' PDFs are 404

- https://antfu.me/talks/2022-10-11
- https://antfu.me/talks/2022-10-16

![Oct-12-2022 23-42-30](https://user-images.githubusercontent.com/8603085/195400767-21e7a9e2-faed-4aa6-81e9-bffbcb4dec6b.gif)


### Linked Issues
- None

### Additional context

- I attempted to see the slides of @antfu's talk at ViteConf 2022 but the PDF version is not accessible.
- I also added a redirect for your next talk on October 16th.

### Future work
- We might have a GitHub Action to check if talks at https://github.com/antfu/talks is defined in https://github.com/antfu/antfu.me/blob/main/_dist_redirects

