### PR TITLE
chore: fix mastodon url

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -15,7 +15,7 @@ Outside of programming, I enjoy doing photography and traveling. Some of my phot
 
 ***
 
-Find me on [GitHub](https://github.com/antfu), [Twitter](https://www.twitter.com/antfu7), [Mastodon](https://elk.zone/m.webtoo.ls/@antfu@m.webtoo.ls), [YouTube](https://www.youtube.com/anthonyfu7), [知乎](https://www.zhihu.com/people/antfu), [微博](https://weibo.com/u/7485197193) or [哔哩哔哩](https://space.bilibili.com/668380).<br>
+Find me on [GitHub](https://github.com/antfu), [Twitter](https://www.twitter.com/antfu7), [Mastodon](https://elk.zone/m.webtoo.ls/@antfu), [YouTube](https://www.youtube.com/anthonyfu7), [知乎](https://www.zhihu.com/people/antfu), [微博](https://weibo.com/u/7485197193) or [哔哩哔哩](https://space.bilibili.com/668380).<br>
 Mail me at [hi@antfu.me](mailto:hi@antfu.me).<br>
 Chat with the community at [my Discord Server](https://chat.antfu.me).
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The url of your mastodon is probably wrong. I couldn't reach your profile with https://elk.zone/m.webtoo.ls/@antfu@m.webtoo.ls.
<img width="2213" alt="https://elk.zone/m.webtoo.ls/@antfu@m.webtoo.ls" src="https://user-images.githubusercontent.com/59875060/212977108-dfe0bb8a-d321-4ed1-9aa1-539936181613.png">

After I removed the `@m.webtoo.ls` in the end, it works (https://elk.zone/m.webtoo.ls/@antfu).
<img width="2213" alt="https://elk.zone/m.webtoo.ls/@antfu" src="https://user-images.githubusercontent.com/59875060/212977607-a1a9f3a9-cbb9-470d-9e1a-cca80a4f8f74.png">


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
