### PR TITLE
chore: typo

### DIFF
--- a/pages/giving-talks.md
+++ b/pages/giving-talks.md
@@ -15,7 +15,7 @@ If you are organizing a frontend related conference or meetup, I'd be happy to g
 - I would expect my travel and accommodation to be covered.
 - I am holding a Chinese passport with Schengen visa. Which means for conferences outside of Schengen area (US, UK, etc.) I would need some assistance on the business visa application.
 
-You can reach me out at [talk@antfu.me](mailto:talk@antfu.me). Looking forward to it!
+You can reach me out at [talks@antfu.me](mailto:talks@antfu.me). Looking forward to it!
 
 ## Information
 

--- a/pages/giving-talks.md
+++ b/pages/giving-talks.md
@@ -15,7 +15,7 @@ If you are organizing a frontend related conference or meetup, I'd be happy to g
 - I would expect my travel and accommodation to be covered.
 - I am holding a Chinese passport with Schengen visa. Which means for conferences outside of Schengen area (US, UK, etc.) I would need some assistance on the business visa application.
 
-You can reach me out at [talks@antfu.me](mailto:talk@antfu.me). Looking forward to it!
+You can reach me out at [talk@antfu.me](mailto:talk@antfu.me). Looking forward to it!
 
 ## Information
 


### PR DESCRIPTION
### Description

There appears to be a discrepancy between the email address listed in the text and the hyperlink provided, potentially leading to confusion for readers.

It is possible that the former is a typo, however, if the latter is inaccurate, you can correct it.