### PR TITLE
fix typo and replace deprecated option

### DIFF
--- a/src/components/icons/SolidLogo.vue
+++ b/src/components/icons/SolidLogo.vue
@@ -1,5 +1,5 @@
 <template>
-  <svg v-pre width="1.2em" hieght="1.2em" viewBox="0 0 166 155.3">
+  <svg v-pre width="1.2em" height="1.2em" viewBox="0 0 166 155.3">
     <path
       d="M163 35S110-4 69 5l-3 1c-6 2-11 5-14 9l-2 3-15 26 26 5c11 7 25 10 38 7l46 9 18-30z"
       fill="#76b3e1"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
 
     Pages({
       extensions: ['vue', 'md'],
-      pagesDir: 'pages',
+      dirs: 'pages',
       extendRoute(route) {
         const path = resolve(__dirname, route.component.slice(1))
 


### PR DESCRIPTION
`pagesDir` of vite-plugin-pages is deprecated.