### PR TITLE
style: improve the display of thead in dark mode

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -186,7 +186,7 @@
   line-height: 1.7142857;
 }
 .prose thead {
-  color: #111827;
+  color: var(--fg-deep);
   font-weight: 600;
   border-bottom-width: 1px;
   border-bottom-color: #d1d5db;


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

improve the display of thead in dark mode

Before:

<img width="735" alt="Screen Shot 2023-07-19 at 7 51 06 PM" src="https://github.com/antfu/antfu.me/assets/71578955/e4ddb774-f606-4866-993a-29e20604d0f6">

After:

<img width="735" alt="Screen Shot 2023-07-19 at 7 50 03 PM" src="https://github.com/antfu/antfu.me/assets/71578955/3f4c6830-f51d-44dd-bdf8-4376c040c242">

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
