### PR TITLE
feat: optimize the color display of "plum" in dark mode

### DIFF
--- a/src/components/Plum.vue
+++ b/src/components/Plum.vue
@@ -1,10 +1,15 @@
 <script setup lang='ts'>
 import type { Fn } from '@vueuse/core'
+import { isDark } from '../logics'
 
 const r180 = Math.PI
 const r90 = Math.PI / 2
 const r15 = Math.PI / 12
-const color = '#88888825'
+
+const lightColor = '#88888825'
+const darkColor = '#aaaaaaaa'
+
+const color = ref('')
 
 const el = ref<HTMLCanvasElement | null>(null)
 
@@ -15,6 +20,12 @@ const start = ref<Fn>(() => {})
 const MIN_BRANCH = 30
 const len = ref(6)
 const stopped = ref(false)
+
+watchEffect(() => {
+  color.value = isDark.value ? darkColor : lightColor
+  stopped.value = true
+  start.value()
+})
 
 function initCanvas(canvas: HTMLCanvasElement, width = 400, height = 400, _dpi?: number) {
   const ctx = canvas.getContext('2d')!
@@ -118,7 +129,7 @@ onMounted(async () => {
     controls.pause()
     ctx.clearRect(0, 0, width, height)
     ctx.lineWidth = 1
-    ctx.strokeStyle = color
+    ctx.strokeStyle = color.value
     prevSteps = []
     steps = [
       () => step(randomMiddle() * size.width, -5, r90),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

First of all, thank you very much for open-sourcing your personal website. I really like it and I'm currently using it.

I noticed that the colors of your plum animation seem a bit dim in dark mode, so I made some improvements.

Perhaps the color `#aaaaaaaa` is a bit too prominent for you. You might want to adjust it a bit. 

Feel free to correct my words

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
