### PR TITLE
chore: remove deprecated property

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,9 +67,6 @@ export default defineConfig({
 
     Vue({
       include: [/\.vue$/, /\.md$/],
-      script: {
-        defineModel: true,
-      },
     }),
 
     Markdown({


### PR DESCRIPTION
> @ deprecated  
defineModel is now a stable feature and always enabled if using Vue 3.4 or above.