### PR TITLE
fix: link typo

### DIFF
--- a/pages/posts/rewrite-in-vite.md
+++ b/pages/posts/rewrite-in-vite.md
@@ -67,7 +67,7 @@ Click it to try 👇🏼
 
 <ToggleTheme class="text-2xl pb-2 pt-1"/>
 
-If you would like to use it in your own apps, I also extract the logic above into [`useDark()` in VueUse](https://vueuse.js.org/core/usedark/). Where you can simply use like this:
+If you would like to use it in your own apps, I also extract the logic above into [`useDark()` in VueUse](https://vueuse.org/core/useDark/). Where you can simply use like this:
 
 ```ts
 import { useDark, useToggle } from '@vueuse/core'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
This fixes a simple typo in https://antfu.me/posts/rewrite-in-vite: the link changed from "https://vueuse.js.org/core/usedark/" to "https://vueuse.org/core/useDark/" for the "useDark() in VueUse"
