### PR TITLE
refactor(perf): improve performance of ArtDots

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
     "matter-attractors": "catalog:frontend",
     "matter-js": "catalog:frontend",
     "nprogress": "catalog:frontend",
-    "p5i": "catalog:frontend",
     "pinia": "catalog:frontend",
+    "pixi.js": "catalog:frontend",
     "shiki": "catalog:frontend",
     "shiki-magic-move": "catalog:frontend",
+    "simplex-noise": "catalog:frontend",
     "vue": "catalog:frontend",
     "vue-router": "catalog:frontend",
     "vue-router-better-scroller": "catalog:frontend"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,18 +179,21 @@ catalogs:
     nprogress:
       specifier: ^0.2.0
       version: 0.2.0
-    p5i:
-      specifier: ^0.6.0
-      version: 0.6.0
     pinia:
       specifier: ^3.0.1
       version: 3.0.1
+    pixi.js:
+      specifier: ^8.9.1
+      version: 8.9.1
     shiki:
       specifier: ^3.2.1
       version: 3.2.1
     shiki-magic-move:
       specifier: ^1.1.0
       version: 1.1.0
+    simplex-noise:
+      specifier: ^4.0.3
+      version: 4.0.3
     vue:
       specifier: ^3.5.13
       version: 3.5.13
@@ -269,18 +272,21 @@ importers:
       nprogress:
         specifier: catalog:frontend
         version: 0.2.0
-      p5i:
-        specifier: catalog:frontend
-        version: 0.6.0
       pinia:
         specifier: catalog:frontend
         version: 3.0.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
+      pixi.js:
+        specifier: catalog:frontend
+        version: 8.9.1
       shiki:
         specifier: catalog:frontend
         version: 3.2.1
       shiki-magic-move:
         specifier: catalog:frontend
         version: 1.1.0(shiki@3.2.1)(vue@3.5.13(typescript@5.8.2))
+      simplex-noise:
+        specifier: catalog:frontend
+        version: 4.0.3
       vue:
         specifier: catalog:frontend
         version: 3.5.13(typescript@5.8.2)
@@ -975,6 +981,9 @@ packages:
   '@octokit/types@13.7.0':
     resolution: {integrity: sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==}
 
+  '@pixi/colord@2.9.6':
+    resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1131,6 +1140,9 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/css-font-loading-module@0.0.12':
+    resolution: {integrity: sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==}
+
   '@types/d3-hierarchy@3.1.7':
     resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
 
@@ -1151,6 +1163,9 @@ packages:
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
+  '@types/earcut@2.1.4':
+    resolution: {integrity: sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
@@ -1536,6 +1551,13 @@ packages:
     resolution: {integrity: sha512-9MiHhAPw+sqCF/RLo8V6HsjRqEdNEWVpDLm2WBRW2G/kSQjb8X901sozXpSCaeLG0f7TEfMrT4XNaA5m1ez7Dg==}
     peerDependencies:
       vue: ^3.5.0
+
+  '@webgpu/types@0.1.60':
+    resolution: {integrity: sha512-8B/tdfRFKdrnejqmvq95ogp8tf52oZ51p3f4QD5m5Paey/qlX4Rhhy5Y8tgFMi7Ms70HzcMMw3EQjH/jdhTwlA==}
+
+  '@xmldom/xmldom@0.8.10':
+    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
+    engines: {node: '>=10.0.0'}
 
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
@@ -1983,6 +2005,9 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
+  earcut@2.2.4:
+    resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -2404,6 +2429,9 @@ packages:
   get-tsconfig@4.8.1:
     resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
 
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
@@ -2613,6 +2641,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  ismobilejs@1.1.1:
+    resolution: {integrity: sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==}
+
   jackspeak@4.0.1:
     resolution: {integrity: sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==}
     engines: {node: 20 || >=22}
@@ -2620,6 +2651,9 @@ packages:
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3079,9 +3113,6 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  p5i@0.6.0:
-    resolution: {integrity: sha512-Hw+J6Fq0ovVnC/h+6wInwZZyAu63eUzFW030+OksWs+MGftExxckKpKG8BRMQakj27oLpVwZEt63jNO17fYwcw==}
-
   package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
 
@@ -3106,6 +3137,9 @@ packages:
   parse-json@8.1.0:
     resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
     engines: {node: '>=18'}
+
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
 
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
@@ -3165,6 +3199,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  pixi.js@8.9.1:
+    resolution: {integrity: sha512-2vF5Yu9WC/83ly2tCGkjb+ZGnrr+vlKtZezmD0AmJEQoYZO5nL94806l+PVcJBKW6qrF0YHtbh0ubb6CB7/8Rg==}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -3418,6 +3455,9 @@ packages:
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  simplex-noise@4.0.3:
+    resolution: {integrity: sha512-qSE2I4AngLQG7BXqoZj51jokT4WUXe8mOBrvfOXpci8+6Yu44+/dD5zqDpOx3Ux792eamTd2lLcI8jqFntk/lg==}
 
   sirv@3.0.1:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
@@ -4511,6 +4551,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 23.0.1
 
+  '@pixi/colord@2.9.6': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4646,6 +4688,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/css-font-loading-module@0.0.12': {}
+
   '@types/d3-hierarchy@3.1.7': {}
 
   '@types/d3-path@3.1.1': {}
@@ -4663,6 +4707,8 @@ snapshots:
   '@types/diacritics@1.3.3': {}
 
   '@types/doctrine@0.0.9': {}
+
+  '@types/earcut@2.1.4': {}
 
   '@types/eslint@9.6.1':
     dependencies:
@@ -5157,6 +5203,10 @@ snapshots:
     dependencies:
       vue: 3.5.13(typescript@5.8.2)
 
+  '@webgpu/types@0.1.60': {}
+
+  '@xmldom/xmldom@0.8.10': {}
+
   '@xmldom/xmldom@0.9.8':
     optional: true
 
@@ -5555,6 +5605,8 @@ snapshots:
       gopd: 1.2.0
 
   duplexer@0.1.2: {}
+
+  earcut@2.2.4: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -6089,6 +6141,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
+
   github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
@@ -6278,6 +6334,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  ismobilejs@1.1.1: {}
+
   jackspeak@4.0.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -6285,6 +6343,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@2.4.2: {}
+
+  js-binary-schema-parser@2.0.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -6936,8 +6996,6 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  p5i@0.6.0: {}
-
   package-json-from-dist@1.0.0: {}
 
   package-manager-detector@0.2.9: {}
@@ -6963,6 +7021,8 @@ snapshots:
       '@babel/code-frame': 7.24.7
       index-to-position: 0.1.2
       type-fest: 4.35.0
+
+  parse-svg-path@0.1.2: {}
 
   parse5@7.2.1:
     dependencies:
@@ -7006,6 +7066,19 @@ snapshots:
       vue: 3.5.13(typescript@5.8.2)
     optionalDependencies:
       typescript: 5.8.2
+
+  pixi.js@8.9.1:
+    dependencies:
+      '@pixi/colord': 2.9.6
+      '@types/css-font-loading-module': 0.0.12
+      '@types/earcut': 2.1.4
+      '@webgpu/types': 0.1.60
+      '@xmldom/xmldom': 0.8.10
+      earcut: 2.2.4
+      eventemitter3: 5.0.1
+      gifuct-js: 2.1.2
+      ismobilejs: 1.1.1
+      parse-svg-path: 0.1.2
 
   pkg-types@1.3.1:
     dependencies:
@@ -7286,6 +7359,8 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
+
+  simplex-noise@4.0.3: {}
 
   sirv@3.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,10 +61,11 @@ catalogs:
     matter-attractors: ^0.1.6
     matter-js: ^0.20.0
     nprogress: ^0.2.0
-    p5i: ^0.6.0
     pinia: ^3.0.1
+    pixi.js: ^8.9.1
     shiki: ^3.2.1
     shiki-magic-move: ^1.1.0
+    simplex-noise: ^4.0.3
     vue: ^3.5.13
     vue-router: ^4.5.0
     vue-router-better-scroller: ^0.0.0

--- a/src/components/ArtDots.vue
+++ b/src/components/ArtDots.vue
@@ -9,7 +9,7 @@ let w = window.innerWidth
 let h = window.innerHeight
 
 const SCALE = 200
-const LENGTH = 10
+const LENGTH = 5
 const SPACING = 15
 
 const noise3d = createNoise3D()

--- a/src/components/ArtDots.vue
+++ b/src/components/ArtDots.vue
@@ -7,7 +7,6 @@ const el = useTemplateRef('el')
 
 let w = window.innerWidth
 let h = window.innerHeight
-const offsetY = window.scrollY
 
 const SCALE = 200
 const LENGTH = 10
@@ -31,7 +30,7 @@ function createDotTexture(app: Application) {
 
 function addPoints({ dotTexture, particleContainer }: { dotTexture: Texture, particleContainer: ParticleContainer }) {
   for (let x = -SPACING / 2; x < w + SPACING; x += SPACING) {
-    for (let y = -SPACING / 2; y < h + offsetY + SPACING; y += SPACING) {
+    for (let y = -SPACING / 2; y < h + SPACING; y += SPACING) {
       const id = `${x}-${y}`
       if (existingPoints.has(id))
         continue
@@ -79,7 +78,7 @@ async function setup() {
       const ny = y + Math.sin(rad) * len
 
       particle.x = nx
-      particle.y = ny - offsetY
+      particle.y = ny
       particle.alpha = (Math.abs(Math.cos(rad)) * 0.8 + 0.2) * opacity
     }
   })

--- a/src/components/ArtDots.vue
+++ b/src/components/ArtDots.vue
@@ -1,24 +1,9 @@
 <script setup lang="ts">
-import type { P5I } from 'p5i'
-import { p5i } from 'p5i'
-import { onMounted, onUnmounted, ref } from 'vue'
+import type { Texture } from 'pixi.js'
+import { Application, Graphics, Particle, ParticleContainer } from 'pixi.js'
+import { createNoise3D } from 'simplex-noise'
 
-const el = ref<HTMLCanvasElement | null>(null)
-
-const {
-  mount,
-  unmount,
-  createCanvas,
-  background,
-  noFill,
-  stroke,
-  noise,
-  noiseSeed,
-  resizeCanvas,
-  cos,
-  sin,
-  TWO_PI,
-} = p5i()
+const el = useTemplateRef('el')
 
 let w = window.innerWidth
 let h = window.innerHeight
@@ -28,80 +13,98 @@ const SCALE = 200
 const LENGTH = 10
 const SPACING = 15
 
-function getForceOnPoint(x: number, y: number, z: number) {
-  // https://p5js.org/reference/#/p5/noise
-  return (noise(x / SCALE, y / SCALE, z) - 0.5) * 2 * TWO_PI
-}
+const noise3d = createNoise3D()
 
 const existingPoints = new Set<string>()
-const points: { x: number, y: number, opacity: number }[] = []
+const points: { x: number, y: number, opacity: number, particle: Particle }[] = []
 
-function addPoints() {
+function getForceOnPoint(x: number, y: number, z: number) {
+  return (noise3d(x / SCALE, y / SCALE, z) - 0.5) * 2 * Math.PI
+}
+
+const mountedScope = effectScope()
+
+function createDotTexture(app: Application) {
+  const g = new Graphics().circle(0, 0, 1).fill(0xCCCCCC)
+  return app.renderer.generateTexture(g)
+}
+
+function addPoints({ dotTexture, particleContainer }: { dotTexture: Texture, particleContainer: ParticleContainer }) {
   for (let x = -SPACING / 2; x < w + SPACING; x += SPACING) {
     for (let y = -SPACING / 2; y < h + offsetY + SPACING; y += SPACING) {
       const id = `${x}-${y}`
       if (existingPoints.has(id))
         continue
       existingPoints.add(id)
-      points.push({ x, y, opacity: Math.random() * 0.5 + 0.5 })
+
+      const particle = new Particle(dotTexture)
+      particle.anchorX = 0.5
+      particle.anchorY = 0.5
+      particleContainer.addParticle(particle)
+
+      const opacity = Math.random() * 0.5 + 0.5
+      points.push({ x, y, opacity, particle })
     }
   }
 }
 
-function setup() {
-  createCanvas(w, h)
-  background('#ffffff')
-  stroke('#ccc')
-  noFill()
+async function setup() {
+  if (el.value == null)
+    return
+  const app = new Application()
+  await app.init({
+    background: '#ffffff',
+    antialias: true,
+    resolution: window.devicePixelRatio,
+    resizeTo: el.value,
+    eventMode: 'none',
+    autoDensity: true,
+  })
+  el.value.appendChild(app.canvas)
 
-  noiseSeed(+new Date())
+  const particleContainer = new ParticleContainer({ dynamicProperties: { position: true, alpha: true } })
+  app.stage.addChild(particleContainer)
 
-  addPoints()
-}
+  const dotTexture = createDotTexture(app)
+  addPoints({ dotTexture, particleContainer })
 
-function draw({ circle }: P5I) {
-  background('#ffffff')
-  const t = +new Date() / 10000
+  app.ticker.add(() => {
+    const t = Date.now() / 10000
 
-  for (const p of points) {
-    const { x, y } = p
-    const rad = getForceOnPoint(x, y, t)
-    const length = (noise(x / SCALE, y / SCALE, t * 2) + 0.5) * LENGTH
-    const nx = x + cos(rad) * length
-    const ny = y + sin(rad) * length
-    stroke(200, 200, 200, (Math.abs(cos(rad)) * 0.8 + 0.2) * p.opacity * 255)
-    circle(nx, ny - offsetY, 1)
-  }
-}
+    for (const p of points) {
+      const { x, y, opacity, particle } = p
+      const rad = getForceOnPoint(x, y, t)
+      const len = (noise3d(x / SCALE, y / SCALE, t * 2) + 0.5) * LENGTH
+      const nx = x + Math.cos(rad) * len
+      const ny = y + Math.sin(rad) * len
 
-function restart() {
-  if (el.value)
-    mount(el.value, { setup, draw })
-}
-
-onMounted(() => {
-  restart()
-
-  useEventListener('resize', () => {
-    w = window.innerWidth
-    h = window.innerHeight
-    resizeCanvas(w, h)
-    addPoints()
+      particle.x = nx
+      particle.y = ny - offsetY
+      particle.alpha = (Math.abs(Math.cos(rad)) * 0.8 + 0.2) * opacity
+    }
   })
 
-  // Uncomment to enable scroll-based animation
-  // Tho there is some lag when scrolling, not sure if it's solvable
-  // useEventListener('scroll', () => {
-  //   offsetY = window.scrollY
-  //   addPoints()
-  // }, { passive: true })
+  mountedScope.run(() => {
+    useEventListener('resize', () => {
+      w = window.innerWidth
+      h = window.innerHeight
+      addPoints({ dotTexture, particleContainer })
+    })
+    onScopeDispose(() => {
+      app?.destroy(true, { children: true, texture: true, textureSource: true })
+    })
+  })
+}
+
+onMounted(async () => {
+  await setup()
 })
 
 onUnmounted(() => {
-  unmount()
+  mountedScope.stop()
 })
 </script>
 
 <template>
-  <div ref="el" z--1 fixed left-0 right-0 top-0 bottom-0 pointer-events-none dark:invert />
+  <div ref="el" z--1 fixed size-screen left-0 right-0 top-0 bottom-0 pointer-events-none dark:invert />
 </template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

closes #86 

Core Concepts:

Each frame involves rendering dots with noise, and while noise computation can’t be significantly optimized, rendering performance can.

Advantages of PixiJS:

- Automatically detects WebGPU or WebGL for optimal hardware acceleration.
- Utilizes particle systems to dramatically reduce draw calls — in this PR, the number of draw calls drops from `8710 (for a 1920×1200 canvas)` to just `1`.

This may not be the ultimate optimization strategy, but it delivers substantial performance gains.

This current CPU and performance inspection:

<img width="1603" alt="The old" src="https://github.com/user-attachments/assets/696e1a7e-db9f-4a77-b2a0-88970d8fec96" />

In this PR:

<img width="1612" alt="The new" src="https://github.com/user-attachments/assets/aae01b2c-8aa9-4bbd-8e4a-5f7b3637bca5" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

#86

### Additional context

And no need to do the scroll processing, I guess.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
