### PR TITLE
fix: declare color-scheme

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2,6 +2,7 @@
   --c-bg: #fff;
   --c-scrollbar: #eee;
   --c-scrollbar-hover: #bbb;
+  color-scheme: light dark;
 }
 
 html {
@@ -14,6 +15,7 @@ html.dark {
   --c-bg: #050505;
   --c-scrollbar: #111;
   --c-scrollbar-hover: #222;
+  color-scheme: dark;
 }
 
 ::selection {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Since Chrome 96, [auto dark theme](https://developer.chrome.com/blog/auto-dark-theme) has been introduced to improve user experience. However, if a website does not specify `color-scheme: dark` when using a dark theme, the color palette will be transformed twice during dark-mode adaptation. By specifying `color-scheme: light dark`, the website informs the browser that it supports both light mode and dark mode.

| Chrome for PC | Edge for Android |
|-|-|
| <img width="1158" height="1428" alt="image" src="https://github.com/user-attachments/assets/557cb76b-ffbe-4d8c-be85-347c8aa4858f" /> | ![b2067ba4324126eb328d3499415a2984_720](https://github.com/user-attachments/assets/a1733e3e-2185-49f9-bb1e-b8fd17654fef)|


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
